### PR TITLE
CAN logging csv with real timestamp

### DIFF
--- a/components/CAN/CAN.cpp
+++ b/components/CAN/CAN.cpp
@@ -4,6 +4,8 @@
 #include "CAN_Config.hpp"
 #include "can_helpers.hpp"
 #include "Logger.h"
+#include "IO.h"
+#include <ctime>
 
 
 static const char *TAG = "CAN"; // Used for ESP_LOGx commands. See ESP-IDF Documentation
@@ -165,6 +167,14 @@ void CAN::rx_task()
                     Logger::LogMessage_t log_message;
                     sprintf(log_message.label, "CAN");
                     sprintf(log_message.message, "%s", log_string);
+                    tm time_struct;
+                    if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
+                        time_t epoch = mktime(&time_struct);
+                        log_message.timestamp = (int64_t)epoch * 1000LL;
+                        // gets real time and conver to unix epoch in milliseconds
+                    } else {
+                        log_message.timestamp = 0; // use relative time as fallback
+                    }
                     Logger::log(log_message);
                 }
                 if (CAN_Rx_IDs.find(rx_msg.identifier) != CAN_Rx_IDs.end())

--- a/components/CAN/CAN.cpp
+++ b/components/CAN/CAN.cpp
@@ -9,6 +9,16 @@
 
 
 static const char *TAG = "CAN"; // Used for ESP_LOGx commands. See ESP-IDF Documentation
+
+// Helper function to get real-time timestamp in milliseconds
+static int64_t get_real_timestamp() {
+    tm time_struct;
+    if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
+        time_t epoch = mktime(&time_struct);
+        return (int64_t)epoch * 1000LL;
+    }
+    return 0; // fallback to relative time will be handled by Logger
+}
 static SemaphoreHandle_t rx_sem = xSemaphoreCreateBinary();
 static TimerHandle_t timerHandle;
 static twai_message_t tx_message = {
@@ -167,14 +177,7 @@ void CAN::rx_task()
                     Logger::LogMessage_t log_message;
                     sprintf(log_message.label, "CAN");
                     sprintf(log_message.message, "%s", log_string);
-                    tm time_struct;
-                    if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
-                        time_t epoch = mktime(&time_struct);
-                        log_message.timestamp = (int64_t)epoch * 1000LL;
-                        // gets real time and conver to unix epoch in milliseconds
-                    } else {
-                        log_message.timestamp = 0; // use relative time as fallback
-                    }
+                    log_message.timestamp = get_real_timestamp();
                     Logger::log(log_message);
                 }
                 if (CAN_Rx_IDs.find(rx_msg.identifier) != CAN_Rx_IDs.end())
@@ -230,14 +233,7 @@ void CAN::tx_CallBack()
             Logger::LogMessage_t log_message;
             sprintf(log_message.label, "CAN");
             sprintf(log_message.message, "%s", log_string);
-            tm time_struct;
-            if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
-                time_t epoch = mktime(&time_struct);
-                log_message.timestamp = (int64_t)epoch * 1000LL;
-                // gets real time and conver to unix epoch in milliseconds
-            } else {
-                log_message.timestamp = 0; // use relative time as fallback
-            }
+            log_message.timestamp = get_real_timestamp();
             Logger::log(log_message);
         }
         if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)
@@ -268,14 +264,7 @@ void CAN::tx_CallBack()
                 Logger::LogMessage_t log_message;
                 sprintf(log_message.label, "CAN");
                 sprintf(log_message.message, "%s", log_string);
-                tm time_struct;
-                if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
-                    time_t epoch = mktime(&time_struct);
-                    log_message.timestamp = (int64_t)epoch * 1000LL;
-                    // gets real time and conver to unix epoch in milliseconds
-                } else {
-                    log_message.timestamp = 0; // use relative time as fallback
-                }
+                log_message.timestamp = get_real_timestamp();
                 Logger::log(log_message);
             }
             if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)
@@ -308,14 +297,7 @@ void CAN::tx_CallBack()
                 Logger::LogMessage_t log_message;
                 sprintf(log_message.label, "CAN");
                 sprintf(log_message.message, "%s", log_string);
-                tm time_struct;
-                if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
-                    time_t epoch = mktime(&time_struct);
-                    log_message.timestamp = (int64_t)epoch * 1000LL;
-                    // gets real time and conver to unix epoch in milliseconds
-                } else {
-                    log_message.timestamp = 0; // use relative time as fallback
-                }
+                log_message.timestamp = get_real_timestamp();
                 Logger::log(log_message);
             }
             if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)

--- a/components/CAN/CAN.cpp
+++ b/components/CAN/CAN.cpp
@@ -230,6 +230,14 @@ void CAN::tx_CallBack()
             Logger::LogMessage_t log_message;
             sprintf(log_message.label, "CAN");
             sprintf(log_message.message, "%s", log_string);
+            tm time_struct;
+            if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
+                time_t epoch = mktime(&time_struct);
+                log_message.timestamp = (int64_t)epoch * 1000LL;
+                // gets real time and conver to unix epoch in milliseconds
+            } else {
+                log_message.timestamp = 0; // use relative time as fallback
+            }
             Logger::log(log_message);
         }
         if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)
@@ -260,6 +268,14 @@ void CAN::tx_CallBack()
                 Logger::LogMessage_t log_message;
                 sprintf(log_message.label, "CAN");
                 sprintf(log_message.message, "%s", log_string);
+                tm time_struct;
+                if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
+                    time_t epoch = mktime(&time_struct);
+                    log_message.timestamp = (int64_t)epoch * 1000LL;
+                    // gets real time and conver to unix epoch in milliseconds
+                } else {
+                    log_message.timestamp = 0; // use relative time as fallback
+                }
                 Logger::log(log_message);
             }
             if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)
@@ -292,6 +308,14 @@ void CAN::tx_CallBack()
                 Logger::LogMessage_t log_message;
                 sprintf(log_message.label, "CAN");
                 sprintf(log_message.message, "%s", log_string);
+                tm time_struct;
+                if (IO::Get()->rtc_handle->getTime(time_struct) == ESP_OK) {
+                    time_t epoch = mktime(&time_struct);
+                    log_message.timestamp = (int64_t)epoch * 1000LL;
+                    // gets real time and conver to unix epoch in milliseconds
+                } else {
+                    log_message.timestamp = 0; // use relative time as fallback
+                }
                 Logger::log(log_message);
             }
             if (twai_transmit(&tx_message, pdMS_TO_TICKS(1000)) != ESP_OK)

--- a/components/IO/Logger.cpp
+++ b/components/IO/Logger.cpp
@@ -94,7 +94,10 @@ void Logger::writeLine(LogMessage_t message)
 
 void Logger::log(LogMessage_t message)
 {
-    message.timestamp = esp_timer_get_time()/1000;
+    // Only use relative time if timestamp is not set (0)
+    if (message.timestamp == 0) {
+        message.timestamp = esp_timer_get_time()/1000;
+    }
     if (logQueue != NULL)
     {
         if (xQueueSendToBack(logQueue, &message, 0) != pdTRUE)


### PR DESCRIPTION
CAN log messages now use the RTC to obtain real-time Unix epoch timestamps in milliseconds when available. The logger falls back to relative time only if a real timestamp is not set, improving log accuracy and consistency.

By including real-time values in the CSV log file, timestamp consistency is maintained regardless of the transmission method used to load data into the database (radio or the fallback method of existing uploads).

Storage implications: currently each relative timestamp is ~3-7 digits. unix epoch is 13 digits